### PR TITLE
Attempt to match mock raw query string before complex match

### DIFF
--- a/domain/mocks.go
+++ b/domain/mocks.go
@@ -89,6 +89,10 @@ var matchesQuery matcher = func(r *http.Request, mock Mock) bool {
 		return true
 	}
 
+	if mock.MatchRequest.Query == r.URL.RawQuery {
+		return true
+	}
+
 	receivedQuery := r.URL.Query()
 	mockQuery, err := url.ParseQuery(mock.MatchRequest.Query)
 	if err != nil {

--- a/domain/mocks_test.go
+++ b/domain/mocks_test.go
@@ -1,11 +1,12 @@
 package domain
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMatcher_Matches(t *testing.T) {
@@ -38,6 +39,38 @@ func TestMatcher_Matches(t *testing.T) {
 			request:          httptest.NewRequest(http.MethodPost, "/pet/search", strings.NewReader(`{"name": "John"}`)),
 			expectedResponse: Response{},
 			expectedOK:       false,
+		},
+		"with query params - page 1": {
+			mock: Mock{
+				MatchRequest: MatchRequest{
+					Method: "GET",
+					Path:   "/user",
+					Query:  "page=1",
+				},
+				Response: Response{
+					Status: 200,
+					Body:   `{"field": "page1"}`,
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/user?page=1", nil),
+			expectedResponse: Response{Body: `{"field": "page1"}`, Status: 200},
+			expectedOK:       true,
+		},
+		"with query params - page 2": {
+			mock: Mock{
+				MatchRequest: MatchRequest{
+					Method: "GET",
+					Path:   "/user",
+					Query:  "page=2",
+				},
+				Response: Response{
+					Status: 200,
+					Body:   `{"field": "page1"}`,
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/user?page=2", nil),
+			expectedResponse: Response{Body: `{"field": "page2"}`, Status: 200},
+			expectedOK:       true,
 		},
 	}
 	for name, test := range tests {

--- a/go.sum
+++ b/go.sum
@@ -9,13 +9,9 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/steinfletcher/apitest v1.3.13 h1:E0BAXde9dke8jEjK1hqTGvmI20vyyfC+xSdE9nmTc84=
-github.com/steinfletcher/apitest v1.3.13/go.mod h1:pCHKMM2TcH1pezw/xbmilaCdK9/dGsoCZBafwaqJ2sY=
 github.com/steinfletcher/apitest v1.4.4 h1:ZT/Wa3J615x7mBuarTf92o43AseYfHEFsLhnl1dBkl4=
 github.com/steinfletcher/apitest v1.4.4/go.mod h1:yaYc9GDlj4fa0qUUDywqAmrELlNbDrBwd36Zgo5hMZo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=


### PR DESCRIPTION
The complex parsing and matching method sometimes fails if the regex
isn't quite right, and some users just want to perform an exact string
match. So we attempt an exact match before parsing the query string