### PR TITLE
Change links to point to localhost on local dev

### DIFF
--- a/domain/config.go
+++ b/domain/config.go
@@ -17,14 +17,15 @@ type Config struct {
 }
 
 type Route struct {
-	Type                 string            `json:"type"`
-	PathPattern          *PathPattern      `json:"path_pattern"`
-	Backend              *Backend          `json:"backend"`
-	Mock                 *Mock             `json:"mock"`
-	Rewrite              []Rewrite         `json:"rewrite"`
-	Redirect             *Redirect         `json:"redirect"`
-	ProxyPassHeaders     map[string]string `json:"proxy_pass_headers"`
-	ProxyResponseHeaders map[string]string `json:"proxy_response_headers"`
+	Type                      string            `json:"type"`
+	PathPattern               *PathPattern      `json:"path_pattern"`
+	Backend                   *Backend          `json:"backend"`
+	Mock                      *Mock             `json:"mock"`
+	Rewrite                   []Rewrite         `json:"rewrite"`
+	Redirect                  *Redirect         `json:"redirect"`
+	ProxyPassHeaders          map[string]string `json:"proxy_pass_headers"`
+	ProxyResponseHeaders      map[string]string `json:"proxy_response_headers"`
+	ProxyResponseReplacements map[string]string `json:"proxy_response_replacements"`
 }
 
 type Rewrite struct {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -63,6 +63,24 @@ func TestProxy_ProxyBackend_UserProxy_Success(t *testing.T) {
 		End()
 }
 
+func TestProxy_ProxyBackend_ResponseReplacements(t *testing.T) {
+	backendMock := apitest.NewMock().Get("http://localhost:3001/test-ui/users/info").
+		RespondWith().
+		Status(http.StatusOK).
+		Header("test-header", "test-value-1").
+		Body(`{"product_id": "test-value-1"}`).
+		End()
+
+	newApiTest(config(), "http://test-backend", false).
+		Mocks(backendMock).
+		Get("/test-ui/users/info").
+		Expect(t).
+		Status(http.StatusOK).
+		Header("test-header", "test-value-2").
+		Body(`{"product_id": "test-value-2"}`).
+		End()
+}
+
 func TestProxy_Rewrite(t *testing.T) {
 	tests := map[string]struct {
 		pattern string
@@ -334,6 +352,9 @@ func config() domain.Config {
 				},
 				ProxyResponseHeaders: map[string]string{
 					"Cache-Control": "no-cache",
+				},
+				ProxyResponseReplacements: map[string]string{
+					"test-value-1": "test-value-2",
 				},
 			},
 			{


### PR DESCRIPTION
This PR adds ability to set `ProxyResponseReplacements` on a specific path, to allow any strings in response headers and bodies to be replaced.
- G-zipped responses are also handled (they are unzipped before string replacement and re-zipped after)
- Header content length is updated to avoid issues on the client side
- Added an API test

See https://github.com/JSainsburyPLC/gol-ui/pull/1808/files for the corresponding changes in the gol-ui app